### PR TITLE
chore(deps): stop Dependabot proposing web-framework major bumps (nuxt/vue/@nuxtjs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,18 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    # Web-framework stack tracks upstream advplyr/audiobookshelf-app (still Nuxt 2 /
+    # Vue 2). A major jump (Nuxt 3 -> Vue 3) must originate upstream and reach us via
+    # fork-sync, never as a unilateral bump in this fork -- otherwise every sync becomes
+    # a merge war. Block the majors so Dependabot stops re-proposing them; patch/minor
+    # within the current majors still flow.
+    ignore:
+      - dependency-name: "nuxt"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vue"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nuxtjs/*"
+        update-types: ["version-update:semver-major"]
 
   # --- Android native layer ---
   - package-ecosystem: "gradle"


### PR DESCRIPTION
Follow-up to closing #31 (Nuxt 2→3).

abs-app's web layer is a fork of advplyr/audiobookshelf-app, which is still on Nuxt 2 / Vue 2. A framework major here (Nuxt 3, plus the Vue 2→3 jump it forces) has to originate upstream and reach us via fork-sync — carrying it unilaterally would diverge us hard from upstream and make every sync a merge war.

Adds a Dependabot `ignore` on the npm ecosystem for semver-**major** updates of `nuxt`, `vue`, and `@nuxtjs/*`, so those stop showing up as PRs. Patch/minor within the current majors still flow, and security updates are unaffected (ignore governs version updates only). When upstream moves to Nuxt 3, we pick it up through the normal sync.