### PR TITLE
chore(deps): group github-actions bumps into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,3 +84,10 @@ updates:
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
+    # Batch all action bumps into one PR — keeps the codeql-action init/analyze/
+    # upload-sarif refs in lockstep (a split bump mismatches CodeQL versions) and
+    # avoids weekly action-PR pile-ups.
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group all github-actions version bumps into one weekly PR instead of N separate ones.

Why: the codeql-action ref appears across multiple workflow steps (init / analyze / upload-sarif). When Dependabot bumps them in separate PRs, each branch mixes old+new versions and CodeQL fails with a version mismatch — we just hit exactly that on ws-scrcpy-web. Grouping keeps every action ref in lockstep and ends the weekly action-PR pile-ups.

Config-only: adds a `groups: { actions: { patterns: ["*"] } }` block to the github-actions ecosystem.