### PR TITLE
chore(dependabot): group npm + gradle minor+patch, guard auto-merge against closed PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,17 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@nuxtjs/*"
         update-types: ["version-update:semver-major"]
+    # Batch all minor + patch bumps into ONE weekly PR. @capacitor/* core + plugins
+    # must share a version and @nuxtjs/* move together; a split bump ERESOLVEs on
+    # the peer mismatch. Grouping keeps them in lockstep. Majors still open
+    # individually (and the framework majors above stay ignored).
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # --- Android native layer ---
   - package-ecosystem: "gradle"
@@ -67,6 +78,15 @@ updates:
     commit-message:
       prefix: "deps(android)"
       include: "scope"
+    # Batch all minor + patch Gradle bumps into ONE weekly PR; majors open
+    # individually for review.
+    groups:
+      gradle-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # --- GitHub Actions workflows (SHA pin updates) ---
   - package-ecosystem: "github-actions"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,17 @@ jobs:
 
       - name: Enable auto-merge (patch/minor, or any security update)
         if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' || steps.meta.outputs.ghsa-id != '' }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          # Live-state guard: the pull_request event payload is a snapshot from when
+          # the event fired, so it can report "open" for a PR that was closed or
+          # superseded before this job ran -- and `gh pr merge --auto` then fails with
+          # "Pull request is closed". Re-check the CURRENT state right before enabling.
+          state=$(gh pr view "$PR_URL" --json state --jq .state)
+          if [ "$state" != "OPEN" ]; then
+            echo "PR is $state (not OPEN) -- skipping auto-merge enable."
+            exit 0
+          fi
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
1. **npm + gradle minor/patch grouping** — batch non-major bumps into one weekly PR per ecosystem.
2. **Auto-merge live-state guard** — re-check PR state before enabling auto-merge.

## Why
`@capacitor/*` (core + plugins) must share a version, and `@nuxtjs/*` move together;
a split bump ERESOLVEs on the peer mismatch. Grouping keeps each family in lockstep.
Framework majors (nuxt/vue/@nuxtjs) stay ignored per the fork policy; other majors open
individually.

The auto-merge workflow also occasionally ran `gh pr merge --auto` on an already-closed PR
(stale event payload) and errored with "Pull request is closed"; it now checks live state first.

## Risk
Config only — no app/native source changes. (Workflow change takes effect once merged, since
pull_request_target runs from the base branch.)