### PR TITLE
docs: open the whole upstream series instead of gating it in waves

### DIFF
--- a/docs/PR_DECOMPOSITION_PLAN.md
+++ b/docs/PR_DECOMPOSITION_PLAN.md
@@ -4,7 +4,8 @@
 
 This document is the canonical reference for how the Android TV support work
 (originally submitted to `advplyr/audiobookshelf-app` as PR #1843, ~7,000 LOC)
-is being split into a series of 10 smaller, focused PRs.
+is being split into a series of 10 smaller, focused PRs. All of them are
+open now and can be reviewed in any order.
 
 It is hosted on the **fork** (`bilbospocketses/abs-app`) so that upstream PR
 descriptions can link to a single durable plan without bloating the upstream
@@ -27,7 +28,7 @@ This plan addresses both:
 - **Strip non-code from upstream contributions.** Docs, plans, specs, PDF, and
   screenshots stay on the fork. Each upstream PR contributes a single
   ~25-line `docs/pr-NN-<short-name>.md` linking back to fork-hosted context.
-- **Split the upstream code into a 10-PR series across 3 waves.** Average PR
+- **Split the upstream code into a 10-PR series in three dependency layers.** Average PR
   size: ~335 LOC. Largest PR: ~1,630 LOC across 17 focused files.
 - **Refactor the fork to a modular engine structure first** (shipped in v1.0.10)
   so the fork and upstream PRs share one code structure.
@@ -47,7 +48,7 @@ spec.
 
 ## The 10 PRs at a glance
 
-| # | Title | LOC | Wave | Depends on | Files |
+| # | Title | LOC | Layer | Depends on | Files |
 |---|---|---|---|---|---|
 | 1 | Foundation + TV detection | ~125 + 1 binary | 1 | nothing | 11 files (manifest, Kotlin, Vuex, layouts) + tv_banner.png |
 | 2 | Keyboard hygiene (tabindex + keydown.enter.prevent) | ~300 | 1 | nothing | 25+ shared Vue components, additive only |
@@ -71,44 +72,63 @@ engine. Per-PR review size is what matters, and it stays small.
 
 ---
 
-## Wave structure
+## Submission structure — the whole series is open
 
-### Wave 1 — foundation (parallel)
+**All 10 PRs in the series are open simultaneously, plus 2 small companion
+PRs.** They were originally planned as three sequential waves, each opening
+only after the previous one merged. That pacing was chosen to avoid dropping a
+large number of PRs on the maintainer at once. In practice it just meant the
+work sat unreviewable, so the whole series is now on the table and can be
+reviewed and merged in whatever order suits you.
 
-PRs 1, 2, 3, and 4 are independent and submit simultaneously off
-`upstream/master`. Each is small and additive; phone/tablet behavior is
-byte-identical to upstream after Wave 1 lands — the foundation enables TV but
-activates no navigation until Wave 2.
+Nothing about the decomposition itself changed — only when the PRs became
+visible. The layering below is a **merge-order dependency graph**, not a gate:
+
+### Layer 1 — foundation (no dependencies)
+
+PRs 1, 2, 3, and 4 are independent of everything, including each other. Any of
+them can merge first. Each is small and additive; after they land, phone and
+tablet behavior is byte-identical to before — the foundation enables TV but
+activates no navigation.
 
 **One file-overlap note:** PR2 (keyboard hygiene) and PR3 (hide "Go to Web
-Client" on TV) both touch `components/app/SideDrawer.vue`. They edit different
-regions, but whichever merges second may need a trivial rebase. Everything else
-in Wave 1 is fully disjoint.
+Client" on TV) both touch `components/app/SideDrawer.vue`, in different
+regions. Whichever merges second may need a trivial rebase. The same is true of
+PR2 and PR7 (`AudioPlayer.vue`) and PR2 and PR8 (`pages/settings.vue`).
 
-PR3 hides the "Go to Web Client" side-drawer item on Android TV (a TV has no
-browser to hand off to). It is gated on `isAndroidTv`, so it is inert until
-PR1's detection state merges — and harmless before then (the item simply
-remains visible, i.e. upstream's current behavior).
+### Layer 2 — engine (PR6 is stacked on PR5)
 
-### Wave 2 — engine (sequential)
+PR5 (engine kit) ships dormant library code: modules that export functions and
+attach to nothing at runtime. PR6 activates it by registering the global
+keydown listener and wiring the router, store, and event-bus hooks.
 
-PR 5 (engine kit) opens after Wave 1's PR 1 merges. It ships dormant library
-code — modules that export functions but attach to nothing at runtime.
+**PR6's branch is stacked on PR5's**, so until PR5 merges, PR6's diff shows
+PR5's files as well. Merge PR5 first and PR6's diff reduces to its own three
+files. The split exists so the function library can be reviewed separately from
+the wiring that turns it on.
 
-PR 6 (engine integration) stacks on PR 5's branch. It activates the engine by
-registering the global keydown listener and wiring router/store/eventBus hooks.
+Both depend on PR1 for the `isAndroidTv` detection state.
 
-The PR 5/6 split lets the maintainer review the function library separately
-from the wiring that turns it on.
+### Layer 3 — features (independent of each other)
 
-### Wave 3 — features (parallel)
+PRs 7, 8, 9, and 10 each add one TV feature on top of the live engine. They are
+independent of each other and can merge in any order once their dependencies
+are in. PR7, PR8, and PR9 assume PR6; PR10 does not strictly need it.
 
-PRs 7, 8, 9, and 10 open after Wave 2's PR 6 merges. Each is small, independent,
-and adds a TV-specific feature on top of the live engine. Submit in parallel.
+PR10 (author detail page) is arguably not TV-specific — the app has no author
+detail page on any platform today, so mobile users would get the same feature.
+It is flagged in its own PR description for your discretion and can be dropped
+without affecting PRs 1-9.
 
-PR 10 (author detail page) is arguably non-TV-specific — the page itself adds
-general functionality that mobile users could also benefit from. The PR
-description flags this for the maintainer's discretion.
+### Companion PRs (outside the numbered series)
+
+Two small, unrelated PRs are open alongside the series:
+
+- **Android back-button handling** — drawer dismiss on all Android, plus exit
+  when logged out on Home for TV. Independent of the series.
+- **`.gitattributes` LF normalization** — a repo hygiene chore. Heads up that
+  merging it triggers a one-time repo-wide line-ending renormalization, so it
+  may be worth merging on its own, at a quiet moment, or not at all.
 
 ---
 
@@ -139,7 +159,9 @@ upstream PR submission."*
 
 Closed with a comment redirecting to this plan. Draft below — it acknowledges
 the gap since the 2026-05-25 "incoming shortly" comment, and corrects that
-note's "each PR gated on the next" framing (Wave 1 is actually independent):
+note's "each PR gated on the next" framing. Recorded here verbatim as the
+comment that was actually posted; its "later waves" pacing has since been
+dropped in favour of opening the whole series at once (see above):
 
 > Apologies for the gap since my last note here. I used the time to land a few
 > stability fixes on the fork first — most notably a long-standing fast-scroll
@@ -177,21 +199,22 @@ later for their own conventions.
 
 ---
 
-## Estimated timeline
+## Status
 
-| Phase | Activity | Estimated effort |
+| Phase | Activity | Status |
 |---|---|---|
-| 1 | Publish v1.0.10 fork refactor | ✅ done (shipped) |
-| 2 | Close PR #1843 with redirect | ~15 min |
-| 3 | Submit Wave 1 PRs (1, 2, 3, 4) in parallel | ~2.5 hours |
-| 4 | Maintainer review/merge of Wave 1 | (variable, days-weeks per PR) |
-| 5 | Submit Wave 2 PRs (5 + stacked 6) | ~3 hours |
-| 6 | Maintainer review/merge of Wave 2 | (variable) |
-| 7 | Submit Wave 3 PRs (7, 8, 9, 10) in parallel | ~3 hours |
-| 8 | Maintainer review/merge of Wave 3 | (variable) |
-| 9 | Post-merge cleanup | ~1 day |
+| 1 | Publish v1.0.10 fork refactor | done |
+| 2 | Close PR #1843 with redirect to this plan | done |
+| 3 | Submit PRs 1-4 | done (2026-06-06) |
+| 4 | Rebase the series onto current `master` | done (2026-08-25) |
+| 5 | Submit PRs 5-10 + the 2 companion PRs | done (2026-08-25) |
+| 6 | Maintainer review / merge | in your hands |
+| 7 | Post-merge cleanup on the fork | ~1 day |
 
-**Total active effort (excluding maintainer-wait time): ~3-4 days.**
+Every open PR in the series is rebased onto `master` at `12025ab5`
+(`Version bump 0.14.0-beta`) and builds green (`npm run generate`, plus
+`compileReleaseKotlin` for the one PR with Kotlin changes). If `master` moves
+and a PR goes stale, say the word — rebasing the set is quick.
 
 ---
 
@@ -202,7 +225,6 @@ later for their own conventions.
 - **TV focus system architecture overview:** [`docs/TV_FOCUS_SYSTEM.md`](TV_FOCUS_SYSTEM.md)
 - **End-user TV feature documentation:** [`docs/TV_USER_GUIDE.md`](TV_USER_GUIDE.md)
 - **TV user guide PDF (12.7 MB):** [`docs/TV_USER_GUIDE.pdf`](TV_USER_GUIDE.pdf)
-- **Fork active TODO file:** maintained in `~/.claude/projects/.../memory/todo_abs_app.md` (private to maintainer)
 
 ---
 
@@ -218,9 +240,11 @@ spec's Section 10 outlines contingencies for the most likely variations.
 
 ---
 
-**Last updated:** 2026-06-06 — re-validated after v1.0.11 shipped. Now a
-**10-PR series**: a new PR3 (hide "Go to Web Client" on TV) was inserted in
-Wave 1, shifting the former PRs 3-9 to 4-10. Per-PR LOC refreshed against the
-post-v1.0.11 tree — the engine kit (PR5) is now ~1,630 LOC / 17 files and
-integration (PR6) ~615 LOC, reflecting the column-drift fix. Plan originally
-created 2026-05-18.
+**Last updated:** 2026-08-25 — the full series is now open. Previously PRs 1-4
+were open and PRs 5-10 were held pending Wave-1 merges; that sequencing has
+been dropped and everything is submitted. The whole series was rebased from the
+2026-05-13 base onto `master` at `12025ab5`. Two upstream changes interacted
+with the series and were folded in: the `POST_NOTIFICATIONS` permission
+refactor in `MainActivity.kt` (PR1) and the new podcast sort/filter settings
+keys in `store/user.js` (PR4). Plan originally created 2026-05-18; re-validated
+to 10 PRs 2026-06-06.


### PR DESCRIPTION
The 10-PR series was planned as three sequential waves, each opening only after the previous merged. PRs 1-4 went up on 2026-06-06 and have sat with no review since, so the pacing bought nothing — it just kept the other six PRs invisible. We're opening the whole series at once, so the plan doc that every upstream PR links to needs to stop describing a gate that no longer exists.

## What changed

- Replaced the wave-gating section with a submission structure that describes the series as fully open. The 1/2/3 layering is kept but reframed as a merge-order dependency graph rather than a sequencing gate.
- Renamed the `Wave` column to `Layer` and called out the shared-file rebase pairs (PR2/PR3 on `SideDrawer.vue`, PR2/PR7 on `AudioPlayer.vue`, PR2/PR8 on `settings.vue`).
- Documented the PR5/PR6 stack explicitly, and the two companion PRs — including a heads-up that the `.gitattributes` one triggers a repo-wide LF renormalization.
- Swapped the effort estimate for a status table recording the rebase onto `12025ab5`.
- Marked the #1843 closure comment as a verbatim historical record so its "later waves" line isn't read as current policy.
- Dropped a private local filesystem path from the reference list.

The matching `**Wave:**` -> `**Layer:**` change in each `docs/pr-NN-*.md` rides along on the individual upstream PR branches.
