### PR TITLE
docs: changelog entry for the series submission, mark PR_DESCRIPTION superseded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Entries below are quoted from `docs/PR_DESCRIPTION.md` where that file has a per
 
 ## [Unreleased]
 
+### Changed
+
+- **docs: open the whole upstream series instead of gating it in waves** — `docs/PR_DECOMPOSITION_PLAN.md` no longer describes the three sequential waves it was originally planned around. PRs 1-4 opened 2026-06-06 and sat 11 weeks with zero maintainer engagement, so the pacing bought nothing and kept the remaining six PRs invisible. The wave-structure section is replaced by a submission structure describing the series as fully open, with the 1/2/3 layering reframed as a merge-order dependency graph rather than a gate; the table's `Wave` column became `Layer`; the shared-file rebase pairs, the PR5/PR6 stack, and the two companion PRs are documented; the effort estimate became a status table; and a private local filesystem path was dropped from the reference list. (fork PR #66)
+- **docs: mark `docs/PR_DESCRIPTION.md` as a superseded historical draft** — it holds pre-submission draft copy under the retired 9-PR numbering and wave structure. All twelve PR descriptions are now live upstream, so the drafts are no longer the source of truth; a banner points at the live PRs rather than duplicating them into a second file that would drift again.
+
 ## [1.0.11] — 2026-06-06
 
 The **v1.0.11 bundle** — TV init hardening (I2), spatial-nav performance (I4), selector robustness (I5), loading-dot color, and a side-drawer fix that hides the browser-only "Go to Web Client" action on Android TV. Verified via the full 13-batch on-device smoke on the Google TV Streamer 4K.

--- a/docs/PR_DESCRIPTION.md
+++ b/docs/PR_DESCRIPTION.md
@@ -1,4 +1,23 @@
-# Android TV Support — Upstream PR Descriptions (9-PR series)
+# Android TV Support — Upstream PR Descriptions (superseded draft)
+
+> **Superseded 2026-08-25 — historical draft, not current.**
+>
+> This file holds the *pre-submission* draft copy for each upstream PR. All twelve PRs
+> are now open at `advplyr/audiobookshelf-app` as **#1983-#1994**, and their live
+> descriptions are the source of truth — not this file.
+>
+> Two things below are out of date and deliberately left as-is:
+> - **The numbering is the retired 9-PR scheme.** The series was re-validated to 10 PRs
+>   on 2026-06-06 (a new PR3, "hide Go to Web Client on TV", shifted the former PRs 3-9
+>   to 4-10). PR numbers in this file do not match the shipped series.
+> - **The `Wave 1/2/3` headings describe sequencing that no longer exists.** The waves
+>   were dropped on 2026-08-25 and the whole series opened at once; the layering is now
+>   a dependency graph, not a gate.
+>
+> For the current picture see [`PR_DECOMPOSITION_PLAN.md`](PR_DECOMPOSITION_PLAN.md),
+> which is maintained, and the live PRs themselves. Kept only as a record of how the
+> descriptions were drafted.
+
 
 **Supersedes the single ~7,000-LOC PR #1843.** This document holds the ready-to-use
 description for each PR in the 9-PR series that replaces #1843. It is the detailed


### PR DESCRIPTION
Wrap-up doc sweep for the session that opened the full 12-PR upstream set.

### CHANGELOG.md
`[Unreleased]` entries for the `PR_DECOMPOSITION_PLAN.md` rewrite (#66) and for superseding the draft PR descriptions.

### docs/PR_DESCRIPTION.md
Banner marking it a historical draft. It still describes the retired **9-PR** numbering (the series was re-validated to 10 PRs on 2026-06-06) *and* the wave structure (dropped 2026-08-25). All twelve descriptions are now live upstream as #1983-#1994, so the drafts are no longer the source of truth.

Kept as a record of how the descriptions were drafted rather than rewritten into a second copy of twelve live PR bodies that would just drift again.

### Why this surfaced now
Nothing this session touched `PR_DESCRIPTION.md` — which is exactly why it went stale unnoticed. The change that invalidates a doc is rarely the change that edits it, so the sweep is scoped to the whole session's diff rather than the last commit.
